### PR TITLE
Removing probationary members from the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,13 @@ This committee meets at 21:00 UTC on the second Wednesday of every month. All co
 
 ## Committee Members (name order)
 
-- Aaron LaBeau - @biozal
-- AliReza Sabouri - Github [@alirezanet](https://github.com/alirezanet), Twitter [@alirezanett](https://twitter.com/alirezanett)
 - Allan Ritchie - @aritchie
-- Alper Ebicoglu - @ebicoglu
 - Andrew White - @AndrewTriesToCode
 - C. Augusto Proiete - @augustoproiete
 - Calvin A. Allen - @CalvinAllen
 - Dan Siegel - @dansiegel
 - Daniel Valadas - @valadas
 - Dylan Perks - @Perksey
-- Enis Necipoglu - [@enisn](https://github.com/enisn)
-- Furkan Güngör - [@furkandeveloper](https://github.com/furkandeveloper) 
 - Gary Ewan Park - @gep13
 - Geoffrey Huntley - @ghuntley
 - Glenn Watson - @glennawatson
@@ -46,4 +41,3 @@ This committee meets at 21:00 UTC on the second Wednesday of every month. All co
 - Tanner Gooding - @tannergooding
 - Tomáš Herceg - @tomasherceg
 - Tony Qu - @tonyqus
-


### PR DESCRIPTION
See #48

Members can be readded after they attend a meeting and get involved.

I will be force merging this because of suspicious behavior. I apologize if people got improperly caught up in this. We'll discuss in tomorrow's meeting.