### PR TITLE
Sean Killeen Resignation from Maintainers Committee

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ This committee meets at 21:00 UTC on the second Wednesday of every month. All co
 - Pascal Berger - @pascalberger
 - Rob Prouse (Co-Chair) - @rprouse
 - Robin Krom - Github [@Lakritzator](https://github.com/Lakritzator), Twitter [@lakritzator](https://twitter.com/lakritzator)
-- SeanKilleen - Github [@SeanKilleen](https://github.com/SeanKilleen), Twitter [@sjkilleen](https://twitter.com/sjkilleen)
 - Simon Cropp - @SimonCropp
 - Tanner Gooding - @tannergooding
 - Tomáš Herceg - @tomasherceg


### PR DESCRIPTION
I appreciate the goal and aims of the committee and the work that its members are trying to do. But its current format and impact does not align with the work I want to be doing in this space, and so I fondly and respectfully bid the committee farewell. This absence will be small, because I have been unable to fully participate for some time anyway due to other priorities and aforementioned constraints.

I remain available for any conversation / discussion which you feel could benefit from my voice. Tag me in at any time.

I wish you every success in your mission of making the .NET Foundation and the .NET ecosystem better for maintainers!